### PR TITLE
Adding .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache/*


### PR DESCRIPTION
The `.sass-cache` folder isn't something needed to for the repo and can take up quite a bit of space.
